### PR TITLE
improve parsing of PDF files

### DIFF
--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1471,6 +1471,54 @@ pub fn parse_op(
                 ));
             }
         }
+        "k" => {
+            // 'k' sets fill color in Cmyk.
+            if op.operands.len() == 4 {
+                let c = to_f32(&op.operands[0]);
+                let m = to_f32(&op.operands[1]);
+                let y = to_f32(&op.operands[2]);
+                let k = to_f32(&op.operands[3]);
+                out_ops.push(Op::SetFillColor {
+                    col: Color::cmyk(crate::Cmyk {
+                        c,
+                        m,
+                        y,
+                        k,
+                        icc_profile: None,
+                    }),
+                });
+            } else {
+                warnings.push(PdfWarnMsg::error(
+                    page,
+                    op_id,
+                    "Warning: 'k' expects 4 operands".to_string(),
+                ));
+            }
+        }
+        "K" => {
+            // 'K' sets stroke (outline) color in CMYK.
+            if op.operands.len() == 4 {
+                let c = to_f32(&op.operands[0]);
+                let m = to_f32(&op.operands[1]);
+                let y = to_f32(&op.operands[2]);
+                let k = to_f32(&op.operands[3]);
+                out_ops.push(Op::SetOutlineColor {
+                    col: Color::Cmyk(crate::Cmyk {
+                        c,
+                        m,
+                        y,
+                        k,
+                        icc_profile: None,
+                    }),
+                });
+            } else {
+                warnings.push(PdfWarnMsg::error(
+                    page,
+                    op_id,
+                    "Warning: 'K' expects 4 operands".to_string(),
+                ));
+            }
+        }
         "g" => {
             // 'g' sets the fill color in grayscale.
             if op.operands.len() == 1 {
@@ -2046,10 +2094,10 @@ pub fn parse_op(
                 });
                 state.path_builder.close_path();
 
-                // In PDF 're' implicitly fills and strokes
+                // In PDF 're' implicitly strokes but doesn't fill
                 let path = state
                     .path_builder
-                    .build(PaintMode::FillStroke, WindingOrder::NonZero);
+                    .build(PaintMode::Stroke, WindingOrder::NonZero);
                 out_ops.push(path_to_op(&path));
                 state.path_builder.clear();
             } else {

--- a/src/font.rs
+++ b/src/font.rs
@@ -1052,7 +1052,17 @@ impl ParsedFont {
             }
         };
 
-        let font = allsorts_subset_browser::font::Font::new(provider).unwrap();
+        let font = match allsorts_subset_browser::font::Font::new(provider) {
+            Ok(font) => font,
+            Err(err) => {
+                warnings.push(PdfWarnMsg::error(
+                    0,
+                    0,
+                    format!("Error parsing font: {:?}", err),
+                ));
+                return None;
+            }
+        };
         let provider = &font.font_table_provider;
 
         let font_name = provider.table_data(tag::NAME).ok().and_then(|name_data| {

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1389,10 +1389,9 @@ fn encode_text_to_utf16be(text: &str) -> lopdf::Object {
     let mut bytes = vec![0xFE, 0xFF];
 
     // Encode as UTF-16BE
-    for c in text.chars() {
-        let code_point = c as u16;
-        bytes.push((code_point >> 8) as u8);
-        bytes.push((code_point & 0xFF) as u8);
+    for c in text.encode_utf16() {
+        bytes.push((c >> 8) as u8);
+        bytes.push((c & 0xFF) as u8);
     }
 
     // Return as a Hex String


### PR DESCRIPTION
- added support for Cmyk stroke/key color operations during parse
- "re" rectangles in PDFs only stroke, but don't fill by default
- when parsing a type0 font, the DescendantFonts table entry is sometimes returned as a simple reference (even though it should be an array according to the PDF specification), added support for both cases
- use proper UTF16 encoding for document meta data
- fixes #245 
- fixes #247 