### PR TITLE
fix compression during serialization and workaround for incorrect BDC operand being serialized as an array

### DIFF
--- a/examples/bookmarks.rs
+++ b/examples/bookmarks.rs
@@ -92,12 +92,12 @@ fn main() {
         // Create a link annotation to page 2
         Op::LinkAnnotation {
             link: LinkAnnotation::new(
-                Rect {
-                    x: Pt(100.0),
-                    y: Pt(170.0),
-                    width: Pt(200.0),
-                    height: Pt(30.0),
-                },
+                Rect::from_xywh(
+                    Pt(100.0),
+                    Pt(170.0),
+                    Pt(200.0),
+                    Pt(30.0),
+                ),
                 Actions::go_to(Destination::Xyz {
                     page: 2,
                     left: Some(0.0),
@@ -207,12 +207,12 @@ fn main() {
         // External link annotation
         Op::LinkAnnotation {
             link: LinkAnnotation::new(
-                Rect {
-                    x: Pt(100.0),
-                    y: Pt(80.0),
-                    width: Pt(200.0),
-                    height: Pt(30.0),
-                },
+                Rect::from_xywh(
+                    Pt(100.0),
+                    Pt(80.0),
+                    Pt(200.0),
+                    Pt(30.0),
+                ),
                 Actions::uri("https://github.com/fschutt/printpdf".to_string()),
                 None,                                   // default border
                 Some(ColorArray::Rgb([0.0, 0.6, 0.0])), // green highlight
@@ -353,12 +353,12 @@ fn main() {
         // Link to Section 2
         Op::LinkAnnotation {
             link: LinkAnnotation::new(
-                Rect {
-                    x: Pt(100.0),
-                    y: Pt(170.0),
-                    width: Pt(200.0),
-                    height: Pt(30.0),
-                },
+                Rect::from_xywh(
+                    Pt(100.0),
+                    Pt(170.0),
+                    Pt(200.0),
+                    Pt(30.0),
+                ),
                 Actions::go_to(Destination::Xyz {
                     page: 3,
                     left: Some(0.0),
@@ -445,12 +445,12 @@ fn main() {
         // Link back to introduction
         Op::LinkAnnotation {
             link: LinkAnnotation::new(
-                Rect {
-                    x: Pt(100.0),
-                    y: Pt(120.0),
-                    width: Pt(200.0),
-                    height: Pt(30.0),
-                },
+                Rect::from_xywh(
+                    Pt(100.0),
+                    Pt(120.0),
+                    Pt(200.0),
+                    Pt(30.0),
+                ),
                 Actions::go_to(Destination::Xyz {
                     page: 1,
                     left: Some(0.0),
@@ -596,12 +596,12 @@ fn main() {
         // Link back to Section 1
         Op::LinkAnnotation {
             link: LinkAnnotation::new(
-                Rect {
-                    x: Pt(100.0),
-                    y: Pt(170.0),
-                    width: Pt(200.0),
-                    height: Pt(30.0),
-                },
+                Rect::from_xywh(
+                    Pt(100.0),
+                    Pt(170.0),
+                    Pt(200.0),
+                    Pt(30.0),
+                ),
                 Actions::go_to(Destination::Xyz {
                     page: 2,
                     left: Some(0.0),
@@ -686,12 +686,12 @@ fn main() {
         // Link back to Introduction
         Op::LinkAnnotation {
             link: LinkAnnotation::new(
-                Rect {
-                    x: Pt(100.0),
-                    y: Pt(120.0),
-                    width: Pt(200.0),
-                    height: Pt(30.0),
-                },
+                Rect::from_xywh(
+                    Pt(100.0),
+                    Pt(120.0),
+                    Pt(200.0),
+                    Pt(30.0),
+                ),
                 Actions::go_to(Destination::Xyz {
                     page: 1,
                     left: Some(0.0),

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -85,9 +85,7 @@ fn main() {
                 winding_order: WindingOrder::NonZero,
             },
         },
-        Op::EndLayer {
-            layer_id: bg_layer_id.clone(),
-        },
+        Op::EndLayer,
     ]);
 
     // Text layer content
@@ -175,9 +173,7 @@ fn main() {
             font: BuiltinFont::Helvetica,
         },
         Op::EndTextSection,
-        Op::EndLayer {
-            layer_id: text_layer_id.clone(),
-        },
+        Op::EndLayer,
     ]);
 
     // Graphics layer content
@@ -346,9 +342,7 @@ fn main() {
                 is_closed: false,
             },
         },
-        Op::EndLayer {
-            layer_id: graphics_layer_id.clone(),
-        },
+        Op::EndLayer,
     ]);
 
     // Create a page with our operations

--- a/examples/shape.rs
+++ b/examples/shape.rs
@@ -119,12 +119,12 @@ fn create_example_page(
             x: Pt(20.0),
             y: page_height.into_pt() - Pt(220.0),
         },
-        &Rect {
-            x: Pt(100.0),
-            y: page_height.into_pt() - Pt(250.0), // Position hole with top at y=250 from top
-            width: Pt(80.0),
-            height: Pt(50.0),
-        },
+        &Rect::from_xywh(
+            Pt(100.0),
+            page_height.into_pt() - Pt(250.0), // Position hole with top at y=250 from top
+            Pt(80.0),
+            Pt(50.0),
+        ),
     ));
 
     // Example 5: Multi-column text
@@ -160,12 +160,12 @@ fn create_example_page(
         doc,
         font_id,
         "This text is centered in a box both horizontally and vertically using text measurement.",
-        Rect {
-            x: Pt(50.0),
-            y: page_height.into_pt() - Pt(510.0), // Position rect with top at y=450
-            width: Pt(300.0),
-            height: Pt(60.0),
-        },
+        Rect::from_xywh(
+            Pt(50.0),
+            page_height.into_pt() - Pt(510.0), // Position rect with top at y=450
+            Pt(300.0),
+            Pt(60.0),
+        ),
     ));
 
     // Add a footer
@@ -437,13 +437,13 @@ fn create_text_with_hole(
         "IMAGE",
     ));
 
-    let hole_relative_to_text_origin = Rect {
-        width: hole_rect_relative_to_page.width,
-        height: hole_rect_relative_to_page.height,
-        x: hole_rect_relative_to_page.x - text_position_relative_to_page.x,
-        y: (hole_rect_relative_to_page.y + hole_rect_relative_to_page.height)
+    let hole_relative_to_text_origin = Rect::from_xywh(
+        hole_rect_relative_to_page.x - text_position_relative_to_page.x,
+        (hole_rect_relative_to_page.y + hole_rect_relative_to_page.height)
             - text_position_relative_to_page.y,
-    };
+        hole_rect_relative_to_page.width,
+        hole_rect_relative_to_page.height,
+    );
 
     let options = TextShapingOptions {
         font_size: Pt(12.0),

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -34,6 +34,8 @@ pub struct Rect {
     pub y: Pt,
     pub width: Pt,
     pub height: Pt,
+    pub mode: Option<PaintMode>,
+    pub winding_order: Option<WindingOrder>,
 }
 
 impl fmt::Debug for Rect {
@@ -67,6 +69,19 @@ impl Rect {
             y: Pt(0.0),
             width,
             height,
+            mode: None,
+            winding_order: None,
+        }
+    }
+
+    pub fn from_xywh(x: Pt, y: Pt, width: Pt, height: Pt) -> Self {
+        Self {
+            x,
+            y,
+            width,
+            height,
+            mode: None,
+            winding_order: None,
         }
     }
 
@@ -75,8 +90,8 @@ impl Rect {
             rings: vec![PolygonRing {
                 points: self.gen_points(),
             }],
-            mode: PaintMode::Fill,
-            winding_order: WindingOrder::NonZero,
+            mode: self.mode.unwrap_or(PaintMode::Fill),
+            winding_order: self.winding_order.unwrap_or(WindingOrder::NonZero),
         }
     }
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -579,12 +579,12 @@ fn displaylist_handle_rect_paginated(
         if let RectBackground::Color(c) = &b.content {
             // PDF coordinates start at the bottom-left, but our rect has top-left origin
             // Convert Y coordinate to PDF space
-            let rect_obj = crate::graphics::Rect {
-                x: Pt(rect.origin.x),
-                y: Pt(page_height.0 - rect.origin.y - rect.size.height), // Invert Y coordinate
-                width: Pt(rect.size.width),
-                height: Pt(rect.size.height),
-            };
+            let rect_obj = crate::graphics::Rect::from_xywh(
+                Pt(rect.origin.x),
+                Pt(page_height.0 - rect.origin.y - rect.size.height), // Invert Y coordinate
+                Pt(rect.size.width),
+                Pt(rect.size.height),
+            );
 
             newops.push(Op::SetFillColor {
                 col: crate::Color::Rgb(crate::Rgb {
@@ -652,12 +652,12 @@ fn displaylist_handle_rect_paginated(
                 .unwrap_or_default(),
         );
 
-        let rect_obj = crate::graphics::Rect {
-            x: Pt(rect.origin.x),
-            y: Pt(page_height.0 - rect.origin.y - rect.size.height), // Invert Y coordinate
-            width: Pt(rect.size.width),
-            height: Pt(rect.size.height),
-        };
+        let rect_obj = crate::graphics::Rect::from_xywh(
+            Pt(rect.origin.x),
+            Pt(page_height.0 - rect.origin.y - rect.size.height), // Invert Y coordinate
+            Pt(rect.size.width),
+            Pt(rect.size.height),
+        );
 
         newops.push(Op::SetOutlineThickness {
             pt: Pt(width_top.to_pixels(rect.size.height)),

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -88,7 +88,7 @@ impl PdfPage {
         self.ops
             .iter()
             .filter_map(|s| match s {
-                Op::BeginLayer { layer_id } | Op::EndLayer { layer_id } => Some(layer_id.clone()),
+                Op::BeginLayer { layer_id } | Op::BeginOptionalContent { layer_id } => Some(layer_id.clone()),
                 _ => None,
             })
             .collect()
@@ -270,7 +270,7 @@ pub enum Op {
     /// Starts a layer
     BeginLayer { layer_id: LayerInternalId },
     /// Ends a layer (is inserted if missing at the page end)
-    EndLayer { layer_id: LayerInternalId },
+    EndLayer,
     /// Saves the graphics configuration on the stack (line thickness, colors, overprint, etc.)
     SaveGraphicsState,
     /// Pops the last graphics configuration state off the stack
@@ -340,6 +340,8 @@ pub enum Op {
     SetLineOffset { multiplier: f32 },
     /// Draw a line (colors, dashes configured earlier)
     DrawLine { line: Line },
+    /// Draw a rectangle
+    DrawRectangle { rectangle: Rect },
     /// Draw a polygon
     DrawPolygon { polygon: Polygon },
     /// Set the transformation matrix for this page. Make sure to save the old graphics state
@@ -373,8 +375,10 @@ pub enum Op {
     /// Begins a marked content sequence with an accompanying property list.
     BeginMarkedContentWithProperties {
         tag: String,
-        properties: Vec<DictItem>,
+        properties: DictItem,
     },
+    /// Starts an optional content layer
+    BeginOptionalContent { layer_id: LayerInternalId },
     /// Defines a marked content point with properties.
     DefineMarkedContentPoint {
         tag: String,
@@ -382,6 +386,10 @@ pub enum Op {
     },
     /// Ends the current marked-content sequence.
     EndMarkedContent,
+    /// Ends the current marked-content sequence.
+    EndMarkedContentWithProperties,
+    /// Ends the current optional content sequence.
+    EndOptionalContent,
     /// Begins a compatibility section (operators inside are ignored).
     BeginCompatibilitySection,
     /// Ends a compatibility section.

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -88,7 +88,7 @@ impl PdfPage {
         self.ops
             .iter()
             .filter_map(|s| match s {
-                Op::BeginLayer { layer_id } | Op::BeginOptionalContent { layer_id } => Some(layer_id.clone()),
+                Op::BeginLayer { layer_id } => Some(layer_id.clone()),
                 _ => None,
             })
             .collect()

--- a/src/render.rs
+++ b/src/render.rs
@@ -628,7 +628,7 @@ fn render_to_svg_internal(
                     tag
                 ));
             }
-            Op::EndMarkedContent => {
+            Op::EndMarkedContent | Op::EndMarkedContentWithProperties => {
                 gst.end_marked_content();
                 if let Some(group_type) = current_svg_group.last() {
                     if group_type == "marked" {
@@ -650,7 +650,7 @@ fn render_to_svg_internal(
                     id
                 ));
             }
-            Op::BeginLayer { layer_id } => {
+            Op::BeginLayer { layer_id } | Op::BeginOptionalContent { layer_id } => {
                 if let Some(layer) = resources.layers.map.get(layer_id) {
                     svg.push_str(&format!(
                         "<g class=\"layer\" id=\"{}\" data-name=\"{}\">",
@@ -661,7 +661,7 @@ fn render_to_svg_internal(
                 }
                 current_svg_group.push(String::from("layer"));
             }
-            Op::EndLayer { .. } => {
+            Op::EndLayer | Op::EndOptionalContent => {
                 if let Some(group_type) = current_svg_group.last() {
                     if group_type == "layer" {
                         current_svg_group.pop();
@@ -828,6 +828,10 @@ fn render_to_svg_internal(
             }
             Op::DrawPolygon { polygon } => {
                 let polygon_svg = render_polygon_to_svg(polygon, &gst, height);
+                svg.push_str(&polygon_svg);
+            }
+            Op::DrawRectangle { rectangle } => {
+                let polygon_svg = render_polygon_to_svg(&rectangle.to_polygon(), &gst, height);
                 svg.push_str(&polygon_svg);
             }
             Op::UseXobject { id, transform } => {

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -25,6 +25,9 @@ impl Svg {
         // parses the resulting PDF again, then extracts the first pages PDF content operations.
 
         // Let's first convert the SVG into an independent chunk.
+        #[cfg(target_arch = "wasm32")]
+        let options = usvg::Options::default();
+        #[cfg(not(target_arch = "wasm32"))]
         let mut options = usvg::Options::default();
         #[cfg(not(target_arch = "wasm32"))]
         {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -53,7 +53,7 @@ pub(crate) fn random_character_string_32() -> String {
 
 // D:20170505150224+02'00'
 #[cfg(target_family = "wasm")]
-pub(crate) fn to_pdf_time_stamp_metadata(date: &OffsetDateTime) -> String {
+pub(crate) fn to_pdf_time_stamp_metadata(_date: &OffsetDateTime) -> String {
     "D:19700101000000+00'00'".to_string()
 }
 

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -45,9 +45,7 @@ fn test_layer_parsing() {
                 winding_order: printpdf::WindingOrder::NonZero,
             },
         },
-        Op::EndLayer {
-            layer_id: layer_id.clone(),
-        },
+        Op::EndLayer,
     ];
 
     let page = PdfPage::new(Mm(210.0), Mm(297.0), ops);
@@ -86,7 +84,7 @@ fn test_layer_parsing() {
     assert!(has_begin_layer, "Begin layer operation not found");
 
     let has_end_layer = parsed_page.ops.iter().any(|op| {
-        if let Op::EndLayer { layer_id: _ } = op {
+        if let Op::EndLayer = op {
             true
         } else {
             false
@@ -304,9 +302,7 @@ fn test_complex_document_parsing() {
         },
         Op::EndTextSection,
         Op::RestoreGraphicsState,
-        Op::EndLayer {
-            layer_id: layer1_id.clone(),
-        },
+        Op::EndLayer,
     ];
 
     // Page 2: Layer 2 with GS 2
@@ -327,9 +323,7 @@ fn test_complex_document_parsing() {
         },
         Op::EndTextSection,
         Op::RestoreGraphicsState,
-        Op::EndLayer {
-            layer_id: layer2_id.clone(),
-        },
+        Op::EndLayer,
     ];
 
     // Page 3: Both layers with different graphics states
@@ -355,9 +349,7 @@ fn test_complex_document_parsing() {
             },
         },
         Op::RestoreGraphicsState,
-        Op::EndLayer {
-            layer_id: layer1_id.clone(),
-        },
+        Op::EndLayer,
         Op::BeginLayer {
             layer_id: layer2_id.clone(),
         },
@@ -382,9 +374,7 @@ fn test_complex_document_parsing() {
         },
         Op::EndTextSection,
         Op::RestoreGraphicsState,
-        Op::EndLayer {
-            layer_id: layer2_id.clone(),
-        },
+        Op::EndLayer,
     ];
 
     let page1 = PdfPage::new(Mm(210.0), Mm(297.0), ops1);
@@ -471,7 +461,7 @@ fn test_complex_document_parsing() {
             .ops
             .iter()
             .filter(|op| {
-                if let Op::EndLayer { layer_id: _ } = op {
+                if let Op::EndLayer = op {
                     true
                 } else {
                     false

--- a/tests/shape.rs
+++ b/tests/shape.rs
@@ -30,12 +30,12 @@ fn test_text_with_hole() {
                      nisl, eget aliquam nisl nisl eget nisl.";
 
     let hole = TextHole {
-        rect: Rect {
-            x: Pt(10.0),
-            y: Pt(10.0),
-            width: Pt(20.0),
-            height: Pt(20.0),
-        },
+        rect: Rect::from_xywh(
+            Pt(10.0),
+            Pt(10.0),
+            Pt(20.0),
+            Pt(20.0),
+        ),
     };
 
     let options = TextShapingOptions {


### PR DESCRIPTION
- provides a workaround when serializing a BeginMarkedContentWithProperties op, only use the first item in the properties vector, as the result needs to be a single dictionary, not an array of dictionaries
- a correct fix would break the API
- page content streams can be compressed, only fonts shouldn't
- fixes #221 
- fixes #248 
- fixes #251 