### PR TITLE
Use correct DPI in usvg::Tree::from_str call

### DIFF
--- a/src/svg.rs
+++ b/src/svg.rs
@@ -35,7 +35,7 @@ impl Svg {
         }
 
         let dpi = 300.0;
-        let tree = usvg::Tree::from_str(svg_string, &options)
+        let tree = usvg::Tree::from_str(svg_string, &usvg::Options { dpi, ..options })
             .map_err(|err| format!("usvg parse: {err}"))?;
 
         let mut co = ConversionOptions::default();


### PR DESCRIPTION
The `usvg::Tree::from_str` call in the `svg` module is using the default options, which render at 96 dpi, but the rest of the document is rendered at 300 dpi. This causes SVGs to not be scaled correctly.

Fix is pretty straightforward.