### PR TITLE
Update lopdf dependency to fix RUSTSEC-2026-0187

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-lopdf = { version = "0.39.0", default-features = false, features = ["time"]}
+lopdf = { version = "0.42.0", default-features = false, features = ["time"]}
 time = { version = "0.3.25", default-features = false, features = ["std", "serde", "serde-human-readable"] }
 allsorts = { version = "0.16.1", default-features = false, features = ["flate2_rust"] }
 image = { version = "0.25", default-features = false, optional = true, features = ["jpeg"] }


### PR DESCRIPTION
## Summary

Updates the lopdf dependency to resolve RustSec advisory RUSTSEC-2026-0187.

## Changes

- Updated lopdf dependency from 0.39.x to 0.42+
- Updated Cargo.lock

## Security

This fixes a stack overflow vulnerability caused by deeply nested PDF objects during parsing.

Fixes #272