### PR TITLE
Embed CID-keyed CFF as bare /CIDFontType0C so charset CIDs render in every viewer (follow-up to #280)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,8 +173,10 @@ jobs:
           cargo run --example otf-font-subset
       - name: Verify code/charset/W/ToUnicode consistency against the source text
         run: |
-          python3 scripts/verify_pdf_font.py font.pdf --expect scripts/otf_font_expected.txt
-          python3 scripts/verify_pdf_font.py font_subset.pdf --expect scripts/otf_font_expected.txt
+          python3 scripts/verify_pdf_font.py font.pdf --expect scripts/otf_font_expected.txt \
+            --source-font examples/assets/fonts/NotoSansJP-Regular.otf
+          python3 scripts/verify_pdf_font.py font_subset.pdf --expect scripts/otf_font_expected.txt \
+            --source-font examples/assets/fonts/NotoSansJP-Regular.otf
       - name: Mock fonts regenerate byte-identically (defined-metrics oracle stays intact)
         run: |
           python3 scripts/gen_mock_fonts.py

--- a/scripts/verify_pdf_font.py
+++ b/scripts/verify_pdf_font.py
@@ -7,9 +7,17 @@ Simulates a spec-following viewer (Acrobat/Preview):
 Asserts, for every text-showing string:
   1. every emitted code resolves to a real glyph in the embedded font program
   2. the resolved glyph is the glyph the original font's cmap assigns to the
-     intended character (ground truth passed via --expect)
-  3. /W widths per code match the embedded font's hmtx advance (scaled to 1000/em)
+     intended character (ground truth passed via --expect; for a bare-CFF
+     program, which carries no cmap, pass the original face via --source-font)
+  3. /W widths per code match the embedded font's advances (scaled to 1000/em)
   4. ToUnicode maps each code to the intended character
+  5. PORTABILITY: a CID-keyed CFF with a non-identity charset must be embedded
+     as a *bare* CFF (/CIDFontType0C), never as a whole OTTO sfnt
+     (/Subtype /OpenType). FreeType-based viewers (PDFium/Chrome, poppler) do
+     not consult the charset for the sfnt wrapper and use codes directly as
+     glyph indices, while Acrobat/Preview resolve them through the charset —
+     with a non-identity charset NO code assignment renders the same in both
+     families, so the wrapper itself is the bug (#280).
 Exit code != 0 on any mismatch.
 """
 import re, zlib, sys, io, argparse
@@ -106,6 +114,9 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument('pdf')
     ap.add_argument('--expect', help='file with the exact text lines shown, one per Tj', default=None)
+    ap.add_argument('--source-font', default=None,
+                    help='original face; supplies the cmap ground truth when the '
+                         'embedded program is a bare CFF (which has no cmap)')
     args = ap.parse_args()
 
     pdf = open(args.pdf, 'rb').read()
@@ -117,6 +128,9 @@ def main():
     content = None
     for num, (head, data) in objs.items():
         if data and data[:4] in (b'OTTO', b'\x00\x01\x00\x00', b'true', b'ttcf'):
+            font_bytes = data
+        elif data and head and b'CIDFontType0C' in head and data[:2] == b'\x01\x00':
+            # bare CFF font program: header major 1, minor 0
             font_bytes = data
         elif head and b'/W' in head and b'/DW' in head and b'Font' in head:
             font_dict = head
@@ -130,37 +144,86 @@ def main():
     assert content is not None, 'no content stream found'
     assert tounicode is not None, 'no ToUnicode CMap found'
 
-    f = TTFont(io.BytesIO(font_bytes))
-    upm = f['head'].unitsPerEm
-    order = f.getGlyphOrder()
-    num_glyphs = f['maxp'].numGlyphs
-    hmtx = f['hmtx']
+    is_sfnt = font_bytes[:4] in (b'OTTO', b'\x00\x01\x00\x00', b'true', b'ttcf')
+
+    if is_sfnt:
+        f = TTFont(io.BytesIO(font_bytes))
+        upm = f['head'].unitsPerEm
+        order = f.getGlyphOrder()
+        num_glyphs = f['maxp'].numGlyphs
+        hmtx = f['hmtx']
+        td = None
+        if 'CFF ' in f:
+            cff = f['CFF '].cff
+            td = cff[cff.fontNames[0]]
+        # cmap of the EMBEDDED font (subset keeps cmap of used chars; full font = all)
+        cmap = f.getBestCmap() if 'cmap' in f else {}
+    else:
+        # bare CFF (/FontFile3 /Subtype /CIDFontType0C): no sfnt tables at all.
+        # Glyph order and charset come from the CFF itself; the advance widths
+        # live in the charstrings; there is no cmap (--source-font supplies it).
+        from fontTools.cffLib import CFFFontSet
+        cffs = CFFFontSet()
+        cffs.decompile(io.BytesIO(font_bytes), None)
+        td = cffs[cffs.fontNames[0]]
+        order = list(td.charset)
+        num_glyphs = len(order)
+        fm = td.rawDict.get('FontMatrix', [0.001, 0, 0, 0.001, 0, 0])
+        upm = round(1 / fm[0]) if fm[0] else 1000
+        hmtx = None
+        cmap = {}
+
+    if args.source_font:
+        src = TTFont(args.source_font)
+        src_cmap = src.getBestCmap()
+        # glyph NAMES are the join key: a verbatim-extracted or allsorts-subset
+        # CFF keeps the original 'cidNNNNN' names, so the source cmap's
+        # char->name assignment is ground truth for the embedded program too.
+        cmap = dict(cmap)
+        cmap.update(src_cmap)
 
     # Viewer-side CID -> GID resolution
-    if 'CFF ' in f:
-        cff = f['CFF '].cff
-        td = cff[cff.fontNames[0]]
-        if hasattr(td, 'ROS'):
-            # CID-keyed: charset[gid] = 'cidXXXXX'; viewer maps CID -> gid via charset
-            cid_to_gid = {}
-            for gid, name in enumerate(td.charset):
-                if name == '.notdef':
-                    cid_to_gid[0] = gid if gid == 0 else cid_to_gid.get(0, 0)
-                    continue
-                assert name.startswith('cid'), f'unexpected charset name {name}'
-                cid_to_gid[int(name[3:])] = gid
-        else:
-            cid_to_gid = None  # name-keyed: CID == GID
+    if td is not None and hasattr(td, 'ROS'):
+        # CID-keyed: charset[gid] = 'cidXXXXX'; viewer maps CID -> gid via charset
+        cid_to_gid = {}
+        for gid, name in enumerate(td.charset):
+            if name == '.notdef':
+                cid_to_gid[0] = gid if gid == 0 else cid_to_gid.get(0, 0)
+                continue
+            assert name.startswith('cid'), f'unexpected charset name {name}'
+            cid_to_gid[int(name[3:])] = gid
     else:
-        cid_to_gid = None  # TrueType with CIDToGIDMap Identity: CID == GID
+        cid_to_gid = None  # name-keyed CFF / TrueType with CIDToGIDMap Identity: CID == GID
+
+    # PORTABILITY GUARD (#280): an sfnt-wrapped CID-keyed CFF with a non-identity
+    # charset cannot render the same in Acrobat/Preview (charset semantics) and
+    # PDFium/poppler (code == glyph-index semantics) no matter which codes we
+    # emit. The only portable encodings are a bare CFF (/CIDFontType0C, both
+    # families become charset-aware) or an identity charset. Fail hard here —
+    # every per-code check below would only validate ONE family's view.
+    if is_sfnt and cid_to_gid is not None \
+            and any(cid != gid for cid, gid in cid_to_gid.items()):
+        print('FAIL: OTTO-wrapped CID-keyed CFF with a NON-IDENTITY charset.')
+        print('  Acrobat/Preview resolve Identity-H codes through the charset;')
+        print('  PDFium (Chrome) and poppler use them directly as glyph indices.')
+        print('  No code assignment satisfies both. Embed the bare CFF table as')
+        print('  /FontFile3 /Subtype /CIDFontType0C, or rewrite the charset to identity.')
+        sys.exit(1)
 
     def resolve(cid):
         if cid_to_gid is None:
             return cid if cid < num_glyphs else None
         return cid_to_gid.get(cid)
 
-    # cmap of the EMBEDDED font (subset keeps cmap of used chars; full font = all)
-    cmap = f.getBestCmap() if 'cmap' in f else {}
+    def glyph_advance(gname):
+        if hmtx is not None:
+            return hmtx[gname][0]
+        # bare CFF: the advance is the charstring's width (fontTools sets
+        # .width while interpreting the program for a pen)
+        from fontTools.pens.basePen import NullPen
+        cs = td.CharStrings[gname]
+        cs.draw(NullPen())
+        return cs.width
 
     widths = parse_w_array(font_dict)
 
@@ -201,7 +264,7 @@ def main():
             w = widths.get(code)
             if w is None:
                 continue  # falls back to DW; only check if declared
-            adv = hmtx[order[gid]][0]
+            adv = glyph_advance(order[gid])
             expected_w = int(adv * 1000 / upm)
             if abs(w - expected_w) > 1:
                 errors.append(

--- a/src/font.rs
+++ b/src/font.rs
@@ -75,6 +75,24 @@ mod parsed_font {
             font_index: usize,
             warnings: &mut Vec<PdfFontParseWarning>,
         ) -> Option<Self> {
+            // A bare CID-keyed CFF table (what we embed as `/FontFile3`
+            // `/CIDFontType0C` — see `crate::font::extract_cid_keyed_cff`) has no
+            // `head`/`hhea`/`maxp`/`hmtx` of its own, which `AzulParsedFont::from_bytes`
+            // requires. Wrap it in a synthetic sfnt just to satisfy that parse.
+            //
+            // The face keeps the SYNTHETIC wrapper (not the original bare bytes) as
+            // its retained source: azul indexes into those retained bytes by
+            // byte-range (`hmtx_range` etc.) computed against whatever it actually
+            // parsed, so swapping in the shorter original afterwards would leave
+            // those ranges pointing past the end of the buffer. This doesn't cost us
+            // round-trip fidelity — `extract_cid_keyed_cff` (the only thing that
+            // reads these bytes back out for embedding) just extracts the `CFF `
+            // table again, which is byte-for-byte the original bare table regardless
+            // of whether the sfnt around it is real or synthesized here (#280).
+            if let Some(wrapped) = crate::font::wrap_bare_cff_as_sfnt(bytes) {
+                let inner = AzulParsedFont::from_bytes(&wrapped, 0, warnings)?;
+                return Some(Self::attach_source_bytes(inner, &wrapped));
+            }
             let inner = AzulParsedFont::from_bytes(bytes, font_index, warnings)?;
             Some(Self::attach_source_bytes(inner, bytes))
         }
@@ -1014,9 +1032,15 @@ pub fn cff_charset_gid_to_cid_map(font_bytes: &[u8], index: usize) -> Option<BTr
         binary::read::ReadScope, cff::CFF, font_data::FontData, tables::FontTableProvider, tag,
     };
 
-    let font_file = ReadScope::new(font_bytes).read::<FontData<'_>>().ok()?;
-    let provider = font_file.table_provider(index).ok()?;
-    let cff_data = provider.read_table_data(tag::CFF).ok()?;
+    // Accept both a whole sfnt (extract the `CFF ` table) and a bare `CFF ` table
+    // — the latter is what we now embed for a CID-keyed CFF (see
+    // `extract_cid_keyed_cff`), and what we read back on parse.
+    let cff_data: Vec<u8> = (|| -> Option<Vec<u8>> {
+        let font_file = ReadScope::new(font_bytes).read::<FontData<'_>>().ok()?;
+        let provider = font_file.table_provider(index).ok()?;
+        Some(provider.read_table_data(tag::CFF).ok()?.into_owned())
+    })()
+    .unwrap_or_else(|| font_bytes.to_vec());
     let cff = ReadScope::new(&cff_data).read::<CFF<'_>>().ok()?;
     let font = cff.fonts.first()?;
     if !font.is_cid_keyed() {
@@ -1068,6 +1092,356 @@ pub fn extract_cid_keyed_cff(font_bytes: &[u8], index: usize) -> Option<Vec<u8>>
         return None;
     }
     Some(cff_data.into_owned())
+}
+
+/// Wrap a bare `CFF ` table (as embedded by [`extract_cid_keyed_cff`]) in a
+/// minimal `OTTO` sfnt, so it can be handed to `AzulParsedFont::from_bytes` —
+/// which requires `head`/`hhea`/`maxp`/`hmtx`, tables a bare CFF byte stream
+/// doesn't carry. Used only to reconstruct an in-memory parsed font when
+/// *reading back* our own bare-CFF `/FontFile3` embedding (see
+/// [`ParsedFont::from_bytes`]); the bytes actually written to a PDF stay
+/// bare — wrapping them there would defeat the FreeType CID-keyed detection
+/// `extract_cid_keyed_cff` exists for (#280).
+///
+/// `None` if `bytes` already looks like an sfnt, or doesn't parse as CFF.
+#[cfg(feature = "text_layout")]
+pub(crate) fn wrap_bare_cff_as_sfnt(bytes: &[u8]) -> Option<Vec<u8>> {
+    use allsorts::{binary::read::ReadScope, cff::CFF};
+
+    let looks_like_sfnt = matches!(bytes.get(..4), Some(magic) if magic == b"OTTO"
+        || magic == [0, 1, 0, 0]
+        || magic == *b"true"
+        || magic == *b"typ1"
+        || magic == *b"ttcf"
+        || magic == *b"wOFF"
+        || magic == *b"wOF2");
+    if looks_like_sfnt {
+        return None;
+    }
+
+    let cff = ReadScope::new(bytes).read::<CFF<'_>>().ok()?;
+    let font = cff.fonts.first()?;
+    let num_glyphs = u16::try_from(font.char_strings_index.len()).ok()?;
+    let widths: Vec<u16> = (0..num_glyphs)
+        .map(|gid| cff_charstring_width(&cff, font, gid))
+        .collect();
+
+    Some(build_minimal_sfnt(bytes, num_glyphs, &widths))
+}
+
+/// A glyph's advance width, read directly from its Type2 charstring —
+/// `defaultWidthX`/`nominalWidthX` plus the optional leading width delta
+/// before the first stack-clearing operator (Adobe TN5177 §16). A bare CFF
+/// table has no `hmtx` of its own to read widths from instead; used by
+/// [`wrap_bare_cff_as_sfnt`] to synthesize one.
+#[cfg(feature = "text_layout")]
+fn cff_charstring_width(
+    cff: &allsorts::cff::CFF<'_>,
+    font: &allsorts::cff::Font<'_>,
+    gid: u16,
+) -> u16 {
+    use allsorts::cff::{CFFVariant, Operator};
+
+    let charstring = font.char_strings_index.read_object(usize::from(gid));
+
+    let (nominal_width, default_width, local_subrs) = match &font.data {
+        CFFVariant::CID(cid) => {
+            let fd = cid.fd_select.font_dict_index(gid).unwrap_or(0) as usize;
+            let pd = cid.private_dicts.get(fd);
+            (
+                pd.and_then(|d| d.get_i32(Operator::NominalWidthX))
+                    .and_then(Result::ok)
+                    .unwrap_or(0),
+                pd.and_then(|d| d.get_i32(Operator::DefaultWidthX))
+                    .and_then(Result::ok)
+                    .unwrap_or(0),
+                cid.local_subr_indices.get(fd).and_then(|s| s.as_ref()),
+            )
+        }
+        CFFVariant::Type1(t1) => (
+            t1.private_dict
+                .get_i32(Operator::NominalWidthX)
+                .and_then(Result::ok)
+                .unwrap_or(0),
+            t1.private_dict
+                .get_i32(Operator::DefaultWidthX)
+                .and_then(Result::ok)
+                .unwrap_or(0),
+            t1.local_subr_index.as_ref(),
+        ),
+    };
+
+    let Some(charstring) = charstring else {
+        return default_width.max(0) as u16;
+    };
+
+    let mut stack: Vec<f64> = Vec::new();
+    let width = match cff_charstring_width_delta(
+        charstring,
+        local_subrs,
+        &cff.global_subr_index,
+        &mut stack,
+        0,
+    ) {
+        Some(delta) => nominal_width as f64 + delta,
+        None => default_width as f64,
+    };
+    width.round().clamp(0.0, u16::MAX as f64) as u16
+}
+
+/// The standard CFF local/global subroutine index bias (Adobe TN5177 §16).
+#[cfg(feature = "text_layout")]
+fn cff_subr_bias(count: usize) -> i32 {
+    if count < 1240 {
+        107
+    } else if count < 33900 {
+        1131
+    } else {
+        32768
+    }
+}
+
+/// Scan a Type2 charstring (following `callsubr`/`callgsubr`, depth-limited
+/// like allsorts' own interpreter) up to its first stack-clearing operator,
+/// returning the leading width delta if the operand count proves one is
+/// present. `stack` is threaded through subroutine calls so operands a
+/// subroutine leaves behind are visible to its caller, matching how a real
+/// Type2 interpreter treats `callsubr`/`callgsubr` as inlining.
+#[cfg(feature = "text_layout")]
+fn cff_charstring_width_delta(
+    charstring: &[u8],
+    local_subrs: Option<&allsorts::cff::MaybeOwnedIndex<'_>>,
+    global_subrs: &allsorts::cff::MaybeOwnedIndex<'_>,
+    stack: &mut Vec<f64>,
+    depth: u8,
+) -> Option<f64> {
+    if depth > 10 {
+        return None;
+    }
+    let mut i = 0usize;
+    while i < charstring.len() {
+        let b0 = charstring[i];
+        match b0 {
+            1 | 3 | 18 | 19 | 20 | 23 => {
+                // hstem/vstem/hstemhm/hintmask/cntrmask/vstemhm: width present iff
+                // the operand count is odd.
+                return (stack.len() % 2 == 1).then(|| stack[0]);
+            }
+            21 => return (stack.len() > 2).then(|| stack[0]), // rmoveto: 2 args
+            22 | 4 => return (stack.len() > 1).then(|| stack[0]), // h/vmoveto: 1 arg
+            14 => return (stack.len() == 1 || stack.len() == 5).then(|| stack[0]), // endchar
+            10 | 29 => {
+                // callsubr / callgsubr
+                let Some(idx) = stack.pop() else { return None };
+                let (subrs, bias) = if b0 == 10 {
+                    let subrs = local_subrs?;
+                    (subrs, cff_subr_bias(subrs.len()))
+                } else {
+                    (global_subrs, cff_subr_bias(global_subrs.len()))
+                };
+                let subr_idx = idx as i32 + bias;
+                let sub_bytes = usize::try_from(subr_idx)
+                    .ok()
+                    .and_then(|si| subrs.read_object(si))?;
+                if let Some(w) =
+                    cff_charstring_width_delta(sub_bytes, local_subrs, global_subrs, stack, depth + 1)
+                {
+                    return Some(w);
+                }
+                i += 1;
+            }
+            11 => return None, // return: no stack-clearing op seen in this chain
+            28 => {
+                if i + 3 > charstring.len() {
+                    return None;
+                }
+                let v = i16::from_be_bytes([charstring[i + 1], charstring[i + 2]]);
+                stack.push(f64::from(v));
+                i += 3;
+            }
+            32..=246 => {
+                stack.push(f64::from(b0) - 139.0);
+                i += 1;
+            }
+            247..=250 => {
+                if i + 2 > charstring.len() {
+                    return None;
+                }
+                stack.push((f64::from(b0) - 247.0) * 256.0 + f64::from(charstring[i + 1]) + 108.0);
+                i += 2;
+            }
+            251..=254 => {
+                if i + 2 > charstring.len() {
+                    return None;
+                }
+                stack.push(-(f64::from(b0) - 251.0) * 256.0 - f64::from(charstring[i + 1]) - 108.0);
+                i += 2;
+            }
+            255 => {
+                if i + 5 > charstring.len() {
+                    return None;
+                }
+                let bits = i32::from_be_bytes([
+                    charstring[i + 1],
+                    charstring[i + 2],
+                    charstring[i + 3],
+                    charstring[i + 4],
+                ]);
+                stack.push(f64::from(bits) / 65536.0);
+                i += 5;
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
+/// Assemble a minimal `OTTO` sfnt around a bare `CFF ` table, synthesizing
+/// the `head`/`hhea`/`maxp`/`hmtx` tables a bare CFF doesn't carry. See
+/// [`wrap_bare_cff_as_sfnt`].
+#[cfg(feature = "text_layout")]
+fn build_minimal_sfnt(cff_bytes: &[u8], num_glyphs: u16, widths: &[u16]) -> Vec<u8> {
+    const UNITS_PER_EM: u16 = 1000;
+
+    let mut head = Vec::with_capacity(54);
+    head.extend_from_slice(&1u16.to_be_bytes()); // majorVersion
+    head.extend_from_slice(&0u16.to_be_bytes()); // minorVersion
+    head.extend_from_slice(&0x0001_0000u32.to_be_bytes()); // fontRevision
+    head.extend_from_slice(&0u32.to_be_bytes()); // checkSumAdjustment
+    head.extend_from_slice(&0x5F0F_3CF5u32.to_be_bytes()); // magicNumber
+    head.extend_from_slice(&0u16.to_be_bytes()); // flags
+    head.extend_from_slice(&UNITS_PER_EM.to_be_bytes());
+    head.extend_from_slice(&0i64.to_be_bytes()); // created
+    head.extend_from_slice(&0i64.to_be_bytes()); // modified
+    head.extend_from_slice(&0i16.to_be_bytes()); // xMin
+    head.extend_from_slice(&0i16.to_be_bytes()); // yMin
+    head.extend_from_slice(&0i16.to_be_bytes()); // xMax
+    head.extend_from_slice(&0i16.to_be_bytes()); // yMax
+    head.extend_from_slice(&0u16.to_be_bytes()); // macStyle
+    head.extend_from_slice(&0u16.to_be_bytes()); // lowestRecPPEM
+    head.extend_from_slice(&2i16.to_be_bytes()); // fontDirectionHint
+    head.extend_from_slice(&0i16.to_be_bytes()); // indexToLocFormat
+    head.extend_from_slice(&0i16.to_be_bytes()); // glyphDataFormat
+
+    let advance_width_max = widths.iter().copied().max().unwrap_or(0);
+    let mut hhea = Vec::with_capacity(36);
+    hhea.extend_from_slice(&1u16.to_be_bytes()); // majorVersion
+    hhea.extend_from_slice(&0u16.to_be_bytes()); // minorVersion
+    hhea.extend_from_slice(&(UNITS_PER_EM as i16 * 8 / 10).to_be_bytes()); // ascender
+    hhea.extend_from_slice(&(-(UNITS_PER_EM as i16) * 2 / 10).to_be_bytes()); // descender
+    hhea.extend_from_slice(&0i16.to_be_bytes()); // lineGap
+    hhea.extend_from_slice(&advance_width_max.to_be_bytes());
+    hhea.extend_from_slice(&0i16.to_be_bytes()); // minLeftSideBearing
+    hhea.extend_from_slice(&0i16.to_be_bytes()); // minRightSideBearing
+    hhea.extend_from_slice(&0i16.to_be_bytes()); // xMaxExtent
+    hhea.extend_from_slice(&1i16.to_be_bytes()); // caretSlopeRise
+    hhea.extend_from_slice(&0i16.to_be_bytes()); // caretSlopeRun
+    hhea.extend_from_slice(&0i16.to_be_bytes()); // caretOffset
+    hhea.extend_from_slice(&0i16.to_be_bytes()); // reserved x4
+    hhea.extend_from_slice(&0i16.to_be_bytes());
+    hhea.extend_from_slice(&0i16.to_be_bytes());
+    hhea.extend_from_slice(&0i16.to_be_bytes());
+    hhea.extend_from_slice(&0i16.to_be_bytes()); // metricDataFormat
+    hhea.extend_from_slice(&num_glyphs.to_be_bytes()); // numberOfHMetrics
+
+    let mut maxp = Vec::with_capacity(6);
+    maxp.extend_from_slice(&0x0000_5000u32.to_be_bytes()); // version 0.5 (CFF)
+    maxp.extend_from_slice(&num_glyphs.to_be_bytes());
+
+    let mut hmtx = Vec::with_capacity(widths.len() * 4);
+    for &w in widths {
+        hmtx.extend_from_slice(&w.to_be_bytes());
+        hmtx.extend_from_slice(&0i16.to_be_bytes()); // lsb
+    }
+
+    // `allsorts::font::Font::new` (built internally by `AzulParsedFont::from_bytes`)
+    // hard-requires a `cmap` with a subtable one of the recognised platform/encoding
+    // pairs finds (`find_good_cmap_subtable`) — a format 6 trimmed table under
+    // Windows/Unicode-BMP satisfies that. A bare CFF genuinely carries no
+    // char->glyph mapping (that's what makes it bare), so this must answer "no
+    // mapping" for every codepoint, not just placeholder-map everything to
+    // .notdef: an empty format 6 table (`entry_count = 0`) does that — every
+    // lookup falls outside its range and `map_glyph` returns `None`, rather than
+    // the `Some(0)` a zero-filled format 0 table would return (indistinguishable
+    // from a genuine, wrong .notdef mapping to callers like
+    // `ParsedFont::lookup_glyph_index`).
+    let mut cmap_subtable = Vec::with_capacity(10);
+    cmap_subtable.extend_from_slice(&6u16.to_be_bytes()); // format 6
+    cmap_subtable.extend_from_slice(&10u16.to_be_bytes()); // length
+    cmap_subtable.extend_from_slice(&0u16.to_be_bytes()); // language
+    cmap_subtable.extend_from_slice(&0u16.to_be_bytes()); // firstCode
+    cmap_subtable.extend_from_slice(&0u16.to_be_bytes()); // entryCount
+
+    let mut cmap = Vec::with_capacity(12 + cmap_subtable.len());
+    cmap.extend_from_slice(&0u16.to_be_bytes()); // version
+    cmap.extend_from_slice(&1u16.to_be_bytes()); // numTables
+    cmap.extend_from_slice(&3u16.to_be_bytes()); // platformID: Windows
+    cmap.extend_from_slice(&1u16.to_be_bytes()); // encodingID: Unicode BMP
+    cmap.extend_from_slice(&12u32.to_be_bytes()); // subtable offset
+    cmap.extend_from_slice(&cmap_subtable);
+
+    build_sfnt(&[
+        (*b"CFF ", cff_bytes),
+        (*b"cmap", &cmap),
+        (*b"head", &head),
+        (*b"hhea", &hhea),
+        (*b"hmtx", &hmtx),
+        (*b"maxp", &maxp),
+    ])
+}
+
+/// Assemble an `OTTO` sfnt from `(tag, data)` tables, already in ascending-tag
+/// order (required by the sfnt table directory). Computes each table's
+/// checksum per the standard sfnt algorithm (sum of big-endian `u32` words,
+/// zero-padded to a 4-byte boundary).
+#[cfg(feature = "text_layout")]
+fn build_sfnt(tables: &[([u8; 4], &[u8])]) -> Vec<u8> {
+    fn checksum(data: &[u8]) -> u32 {
+        let mut sum: u32 = 0;
+        for chunk in data.chunks(4) {
+            let mut word = [0u8; 4];
+            word[..chunk.len()].copy_from_slice(chunk);
+            sum = sum.wrapping_add(u32::from_be_bytes(word));
+        }
+        sum
+    }
+    fn padded_len(len: usize) -> usize {
+        (len + 3) & !3
+    }
+
+    let num_tables = tables.len() as u16;
+    let mut search_range_pow2 = 1u16;
+    let mut entry_selector = 0u16;
+    while search_range_pow2 * 2 <= num_tables {
+        search_range_pow2 *= 2;
+        entry_selector += 1;
+    }
+    let search_range = search_range_pow2 * 16;
+    let range_shift = num_tables * 16 - search_range;
+
+    let mut offset = 12 + 16 * tables.len();
+    let mut directory = Vec::with_capacity(16 * tables.len());
+    let mut data_section = Vec::new();
+    for (tag, data) in tables {
+        directory.extend_from_slice(tag);
+        directory.extend_from_slice(&checksum(data).to_be_bytes());
+        directory.extend_from_slice(&(offset as u32).to_be_bytes());
+        directory.extend_from_slice(&(data.len() as u32).to_be_bytes());
+
+        data_section.extend_from_slice(data);
+        data_section.resize(data_section.len() + (padded_len(data.len()) - data.len()), 0);
+        offset += padded_len(data.len());
+    }
+
+    let mut out = Vec::with_capacity(offset);
+    out.extend_from_slice(b"OTTO");
+    out.extend_from_slice(&num_tables.to_be_bytes());
+    out.extend_from_slice(&search_range.to_be_bytes());
+    out.extend_from_slice(&entry_selector.to_be_bytes());
+    out.extend_from_slice(&range_shift.to_be_bytes());
+    out.extend_from_slice(&directory);
+    out.extend_from_slice(&data_section);
+    out
 }
 
 #[cfg(feature = "text_layout")]

--- a/src/font.rs
+++ b/src/font.rs
@@ -1030,6 +1030,46 @@ pub fn cff_charset_gid_to_cid_map(font_bytes: &[u8], index: usize) -> Option<BTr
     )
 }
 
+/// The bare `CFF ` table of an `OTTO` sfnt, extracted for embedding as
+/// `/FontFile3` `/Subtype /CIDFontType0C` — but only when that CFF is CID-keyed.
+/// `None` for TrueType faces and for name-keyed CFFs, which keep their current
+/// wrappers (code == glyph id is already correct in every viewer there).
+///
+/// The wrapper decides which resolution semantics FreeType-based viewers apply
+/// to the charset-CID codes we emit (see `cff_charset_gid_to_cid_map`). For a
+/// whole OTTO sfnt (`/Subtype /OpenType`) FreeType does not flag the face as
+/// CID-keyed, so PDFium (Chrome) and poppler use the Identity-H codes directly
+/// as glyph indices and never consult the charset — while Acrobat and Preview
+/// resolve the same codes *through* the charset. With a non-identity charset no
+/// code assignment renders identically in both families: emitting glyph ids
+/// broke Acrobat/Preview (#280), emitting charset CIDs breaks Chrome/poppler
+/// (codes above the glyph count draw nothing at all; NotoSansJP puts 日 at CID
+/// 20616 in a 17,802-glyph font). For a *bare* CID-keyed CFF, FreeType sets
+/// FT_FACE_FLAG_CID_KEYED and both families resolve through the charset, so the
+/// CIDs render the same everywhere — which is what the pre-rewrite embedding
+/// from #215 relied on, and why 0.9.x was correct in Acrobat AND Chrome.
+///
+/// The returned bytes are the verbatim table `cff_charset_gid_to_cid_map` read
+/// the charset from, so the emitted codes stay consistent with the embedded
+/// program by construction.
+pub fn extract_cid_keyed_cff(font_bytes: &[u8], index: usize) -> Option<Vec<u8>> {
+    use allsorts::{
+        binary::read::ReadScope, cff::CFF, font_data::FontData, tables::FontTableProvider, tag,
+    };
+
+    if !font_bytes.starts_with(b"OTTO") {
+        return None;
+    }
+    let font_file = ReadScope::new(font_bytes).read::<FontData<'_>>().ok()?;
+    let provider = font_file.table_provider(index).ok()?;
+    let cff_data = provider.read_table_data(tag::CFF).ok()?;
+    let cff = ReadScope::new(&cff_data).read::<CFF<'_>>().ok()?;
+    if !cff.fonts.first()?.is_cid_keyed() {
+        return None;
+    }
+    Some(cff_data.into_owned())
+}
+
 #[cfg(feature = "text_layout")]
 fn get_glyph_width(font: &ParsedFont, gid: u16) -> Option<u16> {
     // `glyph_records_decoded` was replaced by the lazy `get_or_decode_glyph`.

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1750,10 +1750,32 @@ fn add_subset_font_to_pdf(
     // `create_full_font_runtime_info` has already logged that as an error.
     let program = &subset_info.subset_font_bytes;
     let has_font_program = !program.is_empty();
-    let is_cff = program.starts_with(b"OTTO");
 
-    let (sub_type, font_tuple) = if is_cff {
-        // A whole OTTO sfnt goes in /FontFile3 as /Subtype /OpenType (PDF 1.6+).
+    // For a CID-keyed CFF, embed the bare `CFF ` table instead of the whole sfnt:
+    // it is the only wrapper under which every viewer family resolves our
+    // charset-CID codes the same way — see `font::extract_cid_keyed_cff` for the
+    // full story. The extracted bytes are the verbatim table the codes were
+    // derived from, so program and codes stay consistent by construction.
+    let bare_cid_keyed_cff = crate::font::extract_cid_keyed_cff(program, 0);
+    let is_otto = program.starts_with(b"OTTO");
+
+    let (sub_type, font_tuple) = if let Some(cff_table) = bare_cid_keyed_cff {
+        // A bare CFF font program goes in /FontFile3 as /Subtype /CIDFontType0C —
+        // for bare table bytes (unlike a whole sfnt), that name is the truthful one.
+        let font_tuple = has_font_program.then(|| {
+            let font_stream = LoStream::new(
+                LoDictionary::from_iter(vec![("Subtype", Name("CIDFontType0C".into()))]),
+                cff_table,
+            )
+            .with_compression(false);
+
+            ("FontFile3", Reference(doc.add_object(font_stream)))
+        });
+
+        ("CIDFontType0", font_tuple)
+    } else if is_otto {
+        // A whole OTTO sfnt (name-keyed CFF outlines: codes are glyph ids in every
+        // viewer) goes in /FontFile3 as /Subtype /OpenType (PDF 1.6+).
         // /CIDFontType0C would be a lie: that name means a *bare* CFF table, not an sfnt.
         let font_tuple = has_font_program.then(|| {
             let font_stream = LoStream::new(

--- a/tests/font_embedding_mock.rs
+++ b/tests/font_embedding_mock.rs
@@ -305,6 +305,7 @@ fn assert_mock_font_invariants(
     subset: bool,
     expected_subtype: &str,
     expected_font_file: &str,
+    expected_program_magic: &[u8],
     ctx: &str,
 ) {
     let (pdf, warnings) = pdf_with_font(font_bytes, TEXT, subset);
@@ -317,11 +318,11 @@ fn assert_mock_font_invariants(
     // -- container honesty ---------------------------------------------------
     assert_eq!(font.cid_subtype, expected_subtype, "{ctx}: descendant subtype");
     assert_eq!(font.font_file_key, expected_font_file, "{ctx}: font file key");
-    if expected_subtype == "CIDFontType0" {
-        assert_eq!(&font.program[..4], b"OTTO", "{ctx}: CFF program magic");
-    } else {
-        assert_eq!(&font.program[..4], &[0, 1, 0, 0], "{ctx}: glyf program magic");
-    }
+    assert_eq!(
+        &font.program[..4],
+        expected_program_magic,
+        "{ctx}: font program magic"
+    );
 
     // -- subset tag discipline ----------------------------------------------
     // 6-uppercase-letter tag iff actually subset, and BaseFont == FontName.
@@ -415,21 +416,39 @@ fn assert_mock_font_invariants(
 
 #[test]
 fn mock_ttf_full_embed() {
-    assert_mock_font_invariants(MOCK_TTF, false, "CIDFontType2", "FontFile2", "ttf/full");
+    assert_mock_font_invariants(
+        MOCK_TTF,
+        false,
+        "CIDFontType2",
+        "FontFile2",
+        &[0, 1, 0, 0],
+        "ttf/full",
+    );
 }
 
 #[test]
 fn mock_ttf_subset() {
-    assert_mock_font_invariants(MOCK_TTF, true, "CIDFontType2", "FontFile2", "ttf/subset");
+    assert_mock_font_invariants(
+        MOCK_TTF,
+        true,
+        "CIDFontType2",
+        "FontFile2",
+        &[0, 1, 0, 0],
+        "ttf/subset",
+    );
 }
 
 #[test]
 fn mock_cff_named_full_embed() {
+    // Name-keyed CFF: code == gid in every viewer, so the whole OTTO sfnt is
+    // embedded as `/Subtype /OpenType` (`/CIDFontType0C` would be a lie — that
+    // name means a bare CFF table).
     assert_mock_font_invariants(
         MOCK_CFF_NAMED,
         false,
         "CIDFontType0",
         "FontFile3",
+        b"OTTO",
         "cff-named/full",
     );
 }
@@ -441,17 +460,24 @@ fn mock_cff_named_subset() {
         true,
         "CIDFontType0",
         "FontFile3",
+        b"OTTO",
         "cff-named/subset",
     );
 }
 
 #[test]
 fn mock_cff_cid_full_embed() {
+    // CID-keyed CFF: embedded as the bare `CFF ` table (`/CIDFontType0C`) so
+    // FreeType-based viewers flag the face CID-keyed and resolve codes through
+    // the charset the same way Acrobat/Preview do (#280) — see
+    // `font::extract_cid_keyed_cff`. The table's own header starts with the CFF
+    // major/minor version bytes, not `OTTO`.
     assert_mock_font_invariants(
         MOCK_CFF_CID,
         false,
         "CIDFontType0",
         "FontFile3",
+        &[1, 0, 4, 2],
         "cff-cid/full",
     );
 }
@@ -463,6 +489,7 @@ fn mock_cff_cid_subset() {
         true,
         "CIDFontType0",
         "FontFile3",
+        &[1, 0, 4, 2],
         "cff-cid/subset",
     );
 }

--- a/tests/html_visual_subset_glyphs.rs
+++ b/tests/html_visual_subset_glyphs.rs
@@ -275,6 +275,10 @@ fn assert_shaped_glyphs_survive(
     // When the shaper picked a different glyph than the cmap default (Noto CJK
     // digit forms — the #220 body font), rendering must not depend on the
     // subset cmap at all; those chars are covered by the stream checks below.
+    // A CID-keyed CFF subset (NotoSansJP) has no subset cmap to check at all —
+    // it's embedded as a bare CFF table (#280) — so `subset.lookup_glyph_index`
+    // returning `None` there is expected, not a failure; skip rather than
+    // panic, and let `must_reach_cmap` (empty for that probe) enforce coverage.
     let mut cmap_checked: Vec<char> = Vec::new();
     for ch in ['1', '.', '•'] {
         let Some(orig_gid) = original.lookup_glyph_index(ch as u32) else {
@@ -283,9 +287,9 @@ fn assert_shaped_glyphs_survive(
         if !used_sorted.contains(&orig_gid) {
             continue; // painted by a fallback font or as a non-default glyph form
         }
-        let gid = subset
-            .lookup_glyph_index(ch as u32)
-            .unwrap_or_else(|| panic!("subset cmap must map {ch:?}"));
+        let Some(gid) = subset.lookup_glyph_index(ch as u32) else {
+            continue; // bare CID-keyed CFF subset: no cmap to check
+        };
         assert_eq!(
             gid,
             rank(orig_gid),
@@ -376,10 +380,17 @@ fn shaper_glyphs_survive_subsetting_ttf() {
 /// F2b through a CFF (OpenType/OTTO) font — the class of font issue #220's body
 /// text actually fell back to (Noto CJK). NotoSansJP does not ligate Latin "fi",
 /// so only the marker/digit battery applies.
+///
+/// NotoSansJP is CID-keyed, so its subset is embedded as a *bare* CFF table
+/// (`/FontFile3` `/CIDFontType0C`, not an OTTO sfnt) — the fix for #280. A bare
+/// CFF carries no cmap at all, so `must_reach_cmap` is empty here: coverage for
+/// '1'/'.' comes from the content-stream/charset-CID and outline-identity
+/// checks below instead, which is exactly what a spec-following viewer
+/// (Acrobat, Preview) resolves through for this font shape.
 #[test]
 fn shaper_glyphs_survive_subsetting_cff() {
     let (doc, bytes) = render_probe("Subset Probe CFF", CFF_PROBE);
-    assert_shaped_glyphs_survive(&doc, &bytes, CFF_PROBE, false, &['1', '.']);
+    assert_shaped_glyphs_survive(&doc, &bytes, CFF_PROBE, false, &[]);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Implemented with the help of Claude Code. The parser tests are passing as well. Since the parsing logic isn't my main focus here, I'm not entirely sure if this is the best approach—could you take a look? Thank you!

## Problem

03ad4bc correctly switched the Identity-H codes to charset CIDs for CID-keyed CFF fonts — Acrobat and Preview now resolve them right. But the font program is still embedded as the whole OTTO sfnt (`/FontFile3 /Subtype /OpenType`), and for that wrapper FreeType does not flag the face as CID-keyed: PDFium (Chrome) and poppler skip the charset and use each code directly as a glyph index. The fix therefore inverted the #280 symptom instead of removing it — `examples/otf-font.rs` output now renders wrong glyphs / blanks in Chrome (中 = CID 9893 draws whatever sits at *GID* 9893; 日 = CID 20616 exceeds the 17,802-glyph count and draws nothing).

With a non-identity charset inside an sfnt wrapper, no choice of code satisfies both renderer families:

| codes | wrapper | Acrobat / Preview | Chrome (PDFium) / poppler |
|---|---|---|---|
| glyph ids (pre-03ad4bc) | OTTO `/OpenType` | ✗ | ✓ |
| charset CIDs (master)   | OTTO `/OpenType` | ✓ | ✗ |
| charset CIDs (this PR)  | bare CFF `/CIDFontType0C` | ✓ | ✓ |

For a *bare* CID-keyed CFF, FreeType sets `FT_FACE_FLAG_CID_KEYED` and both families resolve codes through the charset, exactly like Acrobat. This is what the pre-rewrite embedding from #215 relied on — and why 0.9.x was correct in Acrobat *and* Chrome.

## Changes

- `font::extract_cid_keyed_cff()`: returns the raw `CFF ` table of an OTTO sfnt iff that CFF is CID-keyed (allsorts `read_table_data`, a verbatim copy — the same bytes `cff_charset_gid_to_cid_map` derived the codes from, so program and codes stay consistent by construction).
- `add_subset_font_to_pdf`: when the extractor returns bytes, embed them as `/FontFile3 /Subtype /CIDFontType0C` (the truthful label for bare table bytes). TrueType, name-keyed CFF and the whole-sfnt `/OpenType` path are byte-identical to today.
- `scripts/verify_pdf_font.py`: reads bare-CFF programs via `fontTools.cffLib` (charset from the CFF, advances from the charstrings, cmap ground truth via a new `--source-font` argument, since a bare CFF carries no `cmap`), and adds a **portability guard**: an sfnt-wrapped CID-keyed CFF with a non-identity charset now fails the oracle outright, because every per-code check would only validate one renderer family's view. This guard fails on current master and passes with this PR — it is the missing second semantics from #280.
- CI passes `--source-font examples/assets/fonts/NotoSansJP-Regular.otf` to the oracle invocations.
- `font::cff_charset_gid_to_cid_map()` and `ParsedFont::from_bytes()`: a bare CFF table carries none of the sfnt tables (`head`/`hhea`/`maxp`/`hmtx`/`cmap`) the rest of the pipeline assumes, so printpdf's own read-back of the PDFs it just wrote lost charset resolution and fell back to using raw codes as glyph ids. `cff_charset_gid_to_cid_map` now reads the charset directly off a bare table instead of only through an sfnt table provider, and `from_bytes` wraps bare CFF bytes in a minimal synthetic OTTO sfnt before handing them to azul-layout — synthesizing `head`/`hhea`/`maxp`/`hmtx` (per-glyph widths read straight out of the Type2 charstrings, since there's no `hmtx` to copy) and an empty `cmap` (so lookups correctly report "no mapping" rather than falsely resolving every code to `.notdef`). The wrapper exists purely to satisfy the parser; the bytes actually embedded in the PDF are untouched. Resolves the round-trip limitation noted below.

## Verification

Beyond the oracle (119 codes across 8 strings, charset resolution + charstring widths + cmap ground truth + ToUnicode text, on both the full-embed and subset PDFs), I compared PDFs with identical CID codes and `/W`/`/ToUnicode`, differing only in the wrapper, in real renderers:

- bare CFF: poppler and PDFium both draw the correct CJK glyphs (per-glyph ink and template correlation against FreeType-rendered references agree across both renderers);
- OTTO wrapper: both draw **zero ink** where CID > numGlyphs (日, 本, 語, 韓, the fullwidth brackets) and a wrong glyph for 中 — the exact mojibake reported in the #280 follow-up screenshot.

Round-trip: printpdf re-parsing its own bare-CFF output now resolves CIDs through the charset correctly again (`tests/font_embedding_mock.rs`), and the existing subsetting/shaping test suite (`tests/html_visual_subset_glyphs.rs`, `tests/font_embedding.rs`) passes with `--features html`, `--no-default-features` and `--features svg`, plus poppler (`pdffonts`/`pdftotext`) and the fontTools oracle against `font.pdf`/`font_subset.pdf`.

## Notes / follow-ups

- The `render.rs` `@font-face` preview fallback keeps receiving the whole sfnt (`subset_font_bytes` is unchanged; extraction happens at PDF-write time), so nothing changes there.