### PR TITLE
fix(bookmarks): preserve same-page insertion order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,7 +394,11 @@ impl PdfDocument {
 
     /// Adds a new page-level bookmark on page `$page`, returning the bookmarks internal ID
     pub fn add_bookmark(&mut self, name: &str, page: usize) -> PageAnnotId {
-        let id = PageAnnotId::new();
+        let id = PageAnnotId(format!(
+            "bookmark_{:020}_{}",
+            self.bookmarks.map.len(),
+            crate::utils::random_character_string_32()
+        ));
         self.bookmarks.map.insert(
             id.clone(),
             PageAnnotation {

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -342,7 +342,7 @@ pub fn to_lopdf_doc(
     if !pdf.bookmarks.map.is_empty() {
         let bookmarks_id = doc.new_object_id();
         let mut bookmarks_sorted = pdf.bookmarks.map.iter().collect::<Vec<_>>();
-        bookmarks_sorted.sort_by(|(_, v), (_, v2)| (v.page, &v.name).cmp(&(v2.page, &v2.name)));
+        bookmarks_sorted.sort_by(|(id, v), (id2, v2)| (v.page, id).cmp(&(v2.page, id2)));
         let bookmarks_sorted = bookmarks_sorted
             .into_iter()
             .filter_map(|(k, v)| {

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -232,6 +232,30 @@ fn test_bookmark_parsing() {
     assert_eq!(chapter3.page, 3);
 }
 
+/// Test that same-page bookmarks keep creation order instead of being sorted by title.
+#[test]
+fn test_same_page_bookmarks_keep_creation_order() {
+    let mut doc = PdfDocument::new("Bookmark Order Test");
+    doc.pages.push(PdfPage::new(Mm(210.0), Mm(297.0), vec![]));
+
+    let _ = doc.add_bookmark("Zulu", 1);
+    let _ = doc.add_bookmark("Alpha", 1);
+    let _ = doc.add_bookmark("Middle", 1);
+
+    let bytes = doc.save(&PdfSaveOptions::default(), &mut Vec::new());
+    let parsed_doc =
+        PdfDocument::parse(&bytes, &PdfParseOptions::default(), &mut Vec::new()).unwrap();
+
+    let names = parsed_doc
+        .bookmarks
+        .map
+        .values()
+        .map(|bookmark| bookmark.name.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(names, vec!["Zulu", "Alpha", "Middle"]);
+}
+
 /// Test complex scenarios with combinations of layers, graphics states, and bookmarks
 #[test]
 fn test_complex_document_parsing() {


### PR DESCRIPTION
Preserve bookmark creation order for multiple bookmarks targeting the same page and add a regression test for same-page bookmark serialization/parsing order