### PR TITLE
examples: add multiple_fonts POC — single CJK OTC, per-language glyph variants, subsetting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,6 +248,11 @@ path = "examples/otf-font-subset.rs"
 required-features = []
 
 [[example]]
+name = "multiple_fonts"
+path = "examples/multiple_fonts.rs"
+required-features = []
+
+[[example]]
 name = "baseline_alignment"
 path = "examples/baseline_alignment.rs"
 required-features = ["html"]

--- a/examples/multiple_fonts.rs
+++ b/examples/multiple_fonts.rs
@@ -12,13 +12,15 @@ fn main() {
 
     let font_slice = include_bytes!("./assets/fonts/SourceHanSerif.ttc");
 
-    // One group per language: each face in the collection cycles JA/KR/TC/SC,
-    // so offset `i` (0..4) selects the language and stepping by 4 walks its faces.
+    // One group per language: each face in the collection cycles
+    // JA/KR/SC/TC (verified against the collection's `name` table — this is
+    // NOT alphabetical), so offset `i` (0..4) selects the language and
+    // stepping by 4 walks its weights.
     let texts = [
         "新しい時代のこころを映すタイプフェイスデザイン",
         "동해 물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세.",
-        "這句話後來演變成「飲水思源」這個成語，意為喝水的時候想一想流水的源頭，比喻不忘本。",
         "这句话后来演变成“饮水思源”这个成语，意为喝水的时候想一想流水的源头，比喻不忘本。",
+        "這句話後來演變成「飲水思源」這個成語，意為喝水的時候想一想流水的源頭，比喻不忘本。",
     ];
 
     let font_groups: Vec<Vec<(FontId, String)>> = (0..4)

--- a/examples/multiple_fonts.rs
+++ b/examples/multiple_fonts.rs
@@ -1,0 +1,108 @@
+//! Same document as `otf-font.rs`, saved with `subset_fonts: true`.
+//!
+//! Writes `font_subset.pdf`. CI validates both PDFs with
+//! `scripts/verify_pdf_font.py` (fontTools) — the subset path exercises the
+//! allsorts CFF subsetter, whose subset charset keeps the ORIGINAL font's CIDs,
+//! so the Identity-H codes must be those CIDs, not the renumbered gids (#280).
+
+use printpdf::*;
+
+fn main() {
+    let mut doc = PdfDocument::new("Demo of multiple fonts, subsetted");
+
+    let font_slice = include_bytes!("./assets/fonts/SourceHanSerif.ttc");
+
+    // One group per language: each face in the collection cycles JA/KR/TC/SC,
+    // so offset `i` (0..4) selects the language and stepping by 4 walks its faces.
+    let texts = [
+        "新しい時代のこころを映すタイプフェイスデザイン",
+        "동해 물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세.",
+        "這句話後來演變成「飲水思源」這個成語，意為喝水的時候想一想流水的源頭，比喻不忘本。",
+        "这句话后来演变成“饮水思源”这个成语，意为喝水的时候想一想流水的源头，比喻不忘本。",
+    ];
+
+    let font_groups: Vec<Vec<(FontId, String)>> = (0..4)
+        .map(|offset| {
+            (offset..28)
+                .step_by(4)
+                .map(|i| {
+                    let parsed_font = ParsedFont::from_bytes(font_slice, i, &mut vec![]).unwrap();
+                    let name = parsed_font
+                        .font_name
+                        .clone()
+                        .unwrap_or_else(|| "Undefined".to_string());
+                    (doc.add_font(&parsed_font), name)
+                })
+                .collect()
+        })
+        .collect();
+
+    let mut ops = vec![
+        Op::StartTextSection,
+        Op::SetTextCursor {
+            pos: Point {
+                x: Mm(10.0).into(),
+                y: Mm(285.0).into(),
+            },
+        },
+        Op::SetLineHeight { lh: Pt(14.0) },
+        Op::SetCharacterSpacing { multiplier: 0.0 },
+    ];
+
+    for (i, (group, text)) in font_groups.iter().zip(texts).enumerate() {
+        for (font_id, font_name) in group {
+            ops.push(Op::SetFont {
+                font: PdfFontHandle::External(font_id.clone()),
+                size: Pt(12.0),
+            });
+            ops.push(Op::ShowText {
+                items: vec![TextItem::Text(font_name.clone())],
+            });
+            ops.push(Op::AddLineBreak);
+            ops.push(Op::ShowText {
+                items: vec![TextItem::Text(text.to_string())],
+            });
+            ops.push(Op::AddLineBreak);
+        }
+        if i + 1 < font_groups.len() {
+            ops.push(Op::SetLineHeight { lh: Pt(8.0) });
+            ops.push(Op::AddLineBreak);
+            ops.push(Op::SetLineHeight { lh: Pt(14.0) });
+        }
+    }
+
+    ops.push(Op::SetTextCursor {
+        pos: Point {
+            x: Mm(120.0).into(),
+            y: Mm(255.0).into(),
+        },
+    });
+    for group in &font_groups {
+        ops.push(Op::SetFont {
+            font: PdfFontHandle::External(group[2].0.clone()),
+            size: Pt(24.0),
+        });
+        ops.push(Op::ShowText {
+            items: vec![TextItem::Text("\u{66DC}".to_string())],
+        });
+    }
+    ops.push(Op::EndTextSection);
+
+    let page = PdfPage::new(Mm(210.0), Mm(297.0), ops.to_vec());
+    let pages = vec![page];
+
+    let mut options = PdfSaveOptions::default();
+    options.subset_fonts = true;
+    options.optimize = false;
+
+    let mut warnings = vec![];
+    let bytes = doc.with_pages(pages).save(&options, &mut warnings);
+
+    std::fs::write("./multiple_fonts.pdf", bytes).unwrap();
+
+    for warning in warnings {
+        if warning.severity != PdfParseErrorSeverity::Info {
+            println!("{:#?}", warning);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This adds a new example, `examples/multiple_fonts.rs`, as a proof of concept
for three things printpdf can do with CJK text that are easy to get wrong:

- **Rendering multiple faces from one OTC on the same page.** [Source Han Serif](https://source.typekit.com/source-han-serif/)
  ships as a "Super OTC" — a single OpenType Collection (`SourceHanSerif.ttc`,
  ~155 MiB) containing all 4 CJK regions (JA/KR/TC/SC) across 7 weights each
  (28 faces total, per the `ttcf` header). The example loads each face it
  needs by index via `ParsedFont::from_bytes(bytes, font_index, ..)`,
  registers them all with `doc.add_font`, and switches between them with
  `Op::SetFont` while laying out a single page — demonstrating how printpdf
  lets a document mix several faces pulled out of one collection, rather
  than requiring one font file per face/language.

- **Han-unified glyphs render per language, not per codepoint.** U+66DC (曜)
  is a textbook case of Han unification: the same Unicode codepoint is drawn
  with subtly different strokes in Japanese, Korean, Traditional Chinese, and
  Simplified Chinese fonts. The example demonstrates the low-level mechanism
  printpdf exposes to get the *correct* regional glyph today: load the
  language-specific face from the collection (via `font_index`) and switch
  `Op::SetFont` per run.

- **Font subsetting keeps output size proportional to used glyphs, not to
  the source font.** With `PdfSaveOptions::subset_fonts = true`, the
  resulting PDF is ~1.81 MiB against a ~155.1 MiB source font collection —
  about 85x smaller (~1.2% of the original), even though the document draws
  from 28 different sub-faces across 4 scripts.

## Non-goals

printpdf only exposes the *primitive*: given a `font_index`, load that face
and let the caller switch fonts per text run. It does not — and should
not — decide *which* face to use for a given language or script. That
decision (detecting the run's language/script and picking the matching face
out of a collection, resolving Unicode variation sequences, etc.) belongs in
a higher-level text-shaping/layout library, e.g. `azul-layout`, sitting above
printpdf. This example exists to prove the low-level primitive works, not to
propose printpdf grow automatic language-aware font selection.

## Changes

- `examples/multiple_fonts.rs` (new): builds the demo document described
  above and writes `multiple_fonts.pdf`.
- `Cargo.toml`: register the `multiple_fonts` example target.

## A note for @fschutt

This is a POC, so whether/how to merge it is entirely your call.

The one thing worth deciding up front: `SourceHanSerif.ttc` (~155 MiB) is
**not included in this PR** — it's over GitHub's 100 MB per-file push limit,
so it can't be added as a normal blob. Right now that means
`examples/multiple_fonts.rs` won't compile out of the box (the
`include_bytes!` target doesn't exist) unless the file is placed locally
first, downloaded from [source.typekit.com/source-han-serif](https://source.typekit.com/source-han-serif/).

Options, roughly in order of effort:
- Track it with Git LFS (repo + GitHub side both need LFS enabled)
- Swap in a smaller, single-weight `.ttc`/`.otf` (loses the "one file, all
  4 languages × 7 weights" part of the demo)
- Leave the asset out of the repo entirely and gate this example out of the
  default `cargo build --examples`/CI matrix, documenting how to fetch the
  font to run it locally

Happy to implement whichever direction you'd prefer, or drop the example if
it's not worth the tradeoff.

## Test plan

- [ ] `cargo run --example multiple_fonts` succeeds and writes
      `multiple_fonts.pdf`
- [ ] Visually confirm JA/KR/TC/SC blocks render with each language's own
      font name/weight label and body text
- [ ] Visually confirm the four U+66DC (曜) glyphs at the top of the page
      are visibly distinct across JA/KR/TC/SC
- [ ] Confirm output PDF size is small relative to the ~155 MiB source font
      (subsetting working as expected)